### PR TITLE
feat(react): warn when DOM events are passed to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,22 @@ await increment(5);
 const result = await fetchData("https://api.example.com");
 ```
 
+> **Important: Event Handler Usage**
+>
+> When using actions as event handlers, always wrap them in an arrow function:
+>
+> ```tsx
+> // ✓ Correct
+> <button onClick={() => increment()}>Click me</button>
+>
+> // ✗ Incorrect - will fail silently
+> <button onClick={increment}>Click me</button>
+> ```
+>
+> Why? When you pass `increment` directly, React calls it with a `MouseEvent` as the first argument. DOM events are not serializable and cannot be sent through Chrome's messaging API, causing the action to fail silently.
+>
+> In development mode, Crann will log a warning if it detects an event being passed to an action.
+
 ### useCrannReady
 
 Check connection status:


### PR DESCRIPTION
## Summary

Adds a runtime warning when DOM/React events are accidentally passed to Crann actions, helping developers catch a common mistake.

## Problem

When using `useCrannActions()` in React, it's easy to write:

```tsx
<button onClick={openSettings}>Settings</button>
```

But this silently fails because React calls `openSettings(mouseEvent)`, and `MouseEvent` objects are not serializable through Chrome's messaging API.

The correct pattern is:

```tsx
<button onClick={() => openSettings()}>Settings</button>
```

## Solution

- Add a `looksLikeEvent()` helper that detects event-like objects
- Show a warning in development mode when an event is detected
- Document this gotcha in the README

## Changes

- `src/react/hooks.tsx`: Add event detection and warning in `useCrannActions`
- `README.md`: Document the event handler pattern in useCrannActions section

## Testing

- All existing tests pass
- Warning only appears in development mode (`NODE_ENV !== 'production'`)